### PR TITLE
Fix a typo in the learnWords method

### DIFF
--- a/core/src/main/scala/com/pepeground/core/repositories/WordRepository.scala
+++ b/core/src/main/scala/com/pepeground/core/repositories/WordRepository.scala
@@ -37,7 +37,7 @@ object WordRepository {
     }.map(rs => rs.long("id")).single().apply()
   }
 
-  def learWords(words: List[String])(implicit session: DBSession): Unit = {
+  def learnWords(words: List[String])(implicit session: DBSession): Unit = {
     val existedWords: List[String] = getByWords(words).map(_.word)
 
     words.foreach { word =>

--- a/core/src/main/scala/com/pepeground/core/services/LearnService.scala
+++ b/core/src/main/scala/com/pepeground/core/services/LearnService.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ListBuffer
 
 class LearnService(words: List[String], chatId: Long)(implicit session: DBSession) {
   def learnPair(): Unit = {
-    WordRepository.learWords(words)
+    WordRepository.learnWords(words)
     var newWords: ListBuffer[Option[String]] = ListBuffer(None)
     val preloadedWords: Map[String, WordEntity] = WordRepository.getByWords(words).map(we => we.word -> we).toMap
 

--- a/core/src/test/scala/com/pepeground/core/repositories/WordRepositoryTest.scala
+++ b/core/src/test/scala/com/pepeground/core/repositories/WordRepositoryTest.scala
@@ -63,7 +63,7 @@ class WordRepositoryTest extends FlatSpec with BeforeAndAfter with AutoRollback 
   behavior of "learnWords"
 
   it should "learn new words" in { implicit session =>
-    WordRepository.learWords(List("hello", "world", "scala"))
+    WordRepository.learnWords(List("hello", "world", "scala"))
 
     val words = WordRepository.getByWords(List("hello", "world", "scala"))
 
@@ -72,7 +72,7 @@ class WordRepositoryTest extends FlatSpec with BeforeAndAfter with AutoRollback 
 
   it should "skip already learned words" in { implicit session =>
     val word2 = WordRepository.create("world")
-    WordRepository.learWords(List("hello", "world", "scala"))
+    WordRepository.learnWords(List("hello", "world", "scala"))
 
     val words = WordRepository.getByWords(List("hello", "world", "scala"))
 


### PR DESCRIPTION
`learWords` -> `learnWords`